### PR TITLE
Only test on supported versions of PHP

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, windows-latest]
-                php: [7.1, 7.2, 7.3, 7.4]
+                php: [7.4, 8.0]
                 dependency-version: [prefer-lowest, prefer-stable]
 
         name: PHP ${{ matrix.php }} - ${{ matrix.dependency-version }} on ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "laravel/framework": "^5.5 || ^6.0 || ^7.0"
+        "laravel/framework": "^5.5 || ^6.0 || ^7.0 || ^8.0"
     },
     "require-dev": {
         "graham-campbell/testbench": "^5.0"

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.4 || ^8.0",
         "laravel/framework": "^5.5 || ^6.0 || ^7.0"
     },
     "require-dev": {


### PR DESCRIPTION
Support for PHP 7.1, 7.2 has been dropped, and 7.3 is only accepting bugfixes. We'll drop them from this library. 

Ref: https://www.php.net/supported-versions.php