### PR TITLE
Runt tests on PHP 8.3

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, windows-latest, macos-latest]
-                php: [8.1, 8.2]
+                php: [8.1, 8.2, 8.3]
                 dependency-version: [lowest, highest]
 
         name: PHP ${{ matrix.php }} - ${{ matrix.dependency-version }} on ${{ matrix.os }}


### PR DESCRIPTION
This PR adds PHP 8.3 to the workflow to also test this library against that.